### PR TITLE
feat(cv): add OpenCV module to GUI

### DIFF
--- a/SAMPLES/cv_basico.wksp
+++ b/SAMPLES/cv_basico.wksp
@@ -1,0 +1,43 @@
+
+WorkspaceBegin: 1.0
+
+VariablesBegin:
+VariablesEnd:
+
+# Load
+Glyph:VGL_CL:vglLoadImage::localhost:1:100:100:: -filename 'files/images/01.png' -iscolor 1 -has_mipmap 0
+
+# Alloc para Rgb2Gray
+Glyph:VGL_CL:vglCreateImage::localhost:2:300:100::
+
+# RGB → Cinza
+Glyph:VGL_CV:vglCvRgb2Gray::localhost:3:500:100::
+
+# Alloc para Blur
+Glyph:VGL_CL:vglCreateImage::localhost:4:300:250::
+
+# Blur 3x3
+Glyph:VGL_CV:vglCvBlurSq3::localhost:5:500:250::
+
+# Salvar resultado
+Glyph:VGL_CL:vglSaveImage::localhost:6:750:250:: -filename 'out/cv_basico_blur.png'
+
+# Mostrar resultado
+Glyph:VGL_CL:ShowImage::localhost:7:750:350::
+
+# Conexões
+NodeConnection:data:1:RETVAL:2:img
+NodeConnection:data:1:RETVAL:3:img_input
+NodeConnection:data:2:RETVAL:3:img_output
+
+NodeConnection:data:3:img_output:4:img
+NodeConnection:data:3:img_output:5:img_input
+NodeConnection:data:4:RETVAL:5:img_output
+
+NodeConnection:data:5:img_output:6:image
+NodeConnection:data:5:img_output:7:image
+
+AnnotationsBegin
+AnnotationsEnd
+
+WorkspaceEnd: 1.0

--- a/SAMPLES/cv_morfologia.wksp
+++ b/SAMPLES/cv_morfologia.wksp
@@ -1,0 +1,58 @@
+
+WorkspaceBegin: 1.0
+
+VariablesBegin:
+VariablesEnd:
+
+# Load
+Glyph:VGL_CL:vglLoadImage::localhost:1:100:150:: -filename 'files/images/01.png' -iscolor 1 -has_mipmap 0
+
+# Alloc Rgb2Gray
+Glyph:VGL_CL:vglCreateImage::localhost:2:300:100::
+
+# RGB → Cinza
+Glyph:VGL_CV:vglCvRgb2Gray::localhost:3:500:100::
+
+# Alloc Dilate
+Glyph:VGL_CL:vglCreateImage::localhost:4:300:250::
+
+# Dilate 5x5
+Glyph:VGL_CV:vglCvDilate::localhost:5:500:250:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 5 -window_size_y 5
+
+# Alloc Erode
+Glyph:VGL_CL:vglCreateImage::localhost:6:300:400::
+
+# Erode 5x5
+Glyph:VGL_CV:vglCvErode::localhost:7:500:400:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 5 -window_size_y 5
+
+# Salvar dilate
+Glyph:VGL_CL:vglSaveImage::localhost:8:750:250:: -filename 'out/cv_dilate.png'
+
+# Salvar erode
+Glyph:VGL_CL:vglSaveImage::localhost:9:750:400:: -filename 'out/cv_erode.png'
+
+# Mostrar erode
+Glyph:VGL_CL:ShowImage::localhost:10:900:400::
+
+# Conexões: load → gray
+NodeConnection:data:1:RETVAL:2:img
+NodeConnection:data:1:RETVAL:3:img_input
+NodeConnection:data:2:RETVAL:3:img_output
+
+# gray → dilate
+NodeConnection:data:3:img_output:4:img
+NodeConnection:data:3:img_output:5:img_input
+NodeConnection:data:4:RETVAL:5:img_output
+NodeConnection:data:5:img_output:8:image
+
+# dilate → erode
+NodeConnection:data:5:img_output:6:img
+NodeConnection:data:5:img_output:7:img_input
+NodeConnection:data:6:RETVAL:7:img_output
+NodeConnection:data:7:img_output:9:image
+NodeConnection:data:7:img_output:10:image
+
+AnnotationsBegin
+AnnotationsEnd
+
+WorkspaceEnd: 1.0

--- a/SAMPLES/cv_operacoes.wksp
+++ b/SAMPLES/cv_operacoes.wksp
@@ -1,0 +1,63 @@
+
+WorkspaceBegin: 1.0
+
+VariablesBegin:
+VariablesEnd:
+
+# Carregar duas imagens (para operações binárias)
+Glyph:VGL_CL:vglLoadImage::localhost:1:100:100:: -filename 'files/images/01.png' -iscolor 1 -has_mipmap 0
+Glyph:VGL_CL:vglLoadImage::localhost:2:100:300:: -filename 'files/images/img2.png' -iscolor 1 -has_mipmap 0
+
+# Alloc para Gray da imagem 1
+Glyph:VGL_CL:vglCreateImage::localhost:3:300:100::
+Glyph:VGL_CV:vglCvRgb2Gray::localhost:4:500:100::
+
+# Alloc para Gray da imagem 2
+Glyph:VGL_CL:vglCreateImage::localhost:5:300:300::
+Glyph:VGL_CV:vglCvRgb2Gray::localhost:6:500:300::
+
+# Alloc para Sub
+Glyph:VGL_CL:vglCreateImage::localhost:7:300:200::
+
+# Sub: gray1 - gray2
+Glyph:VGL_CV:vglCvSub::localhost:8:700:200::
+
+# Alloc para Threshold
+Glyph:VGL_CL:vglCreateImage::localhost:9:300:350::
+
+# Threshold na subtração
+Glyph:VGL_CV:vglCvThreshold::localhost:10:900:200:: -thresh 0.1 -top 1.0
+
+# Salvar e mostrar
+Glyph:VGL_CL:vglSaveImage::localhost:11:1100:150:: -filename 'out/cv_sub.png'
+Glyph:VGL_CL:vglSaveImage::localhost:12:1100:300:: -filename 'out/cv_threshold.png'
+Glyph:VGL_CL:ShowImage::localhost:13:1100:400::
+
+# img1 → gray1
+NodeConnection:data:1:RETVAL:3:img
+NodeConnection:data:1:RETVAL:4:img_input
+NodeConnection:data:3:RETVAL:4:img_output
+
+# img2 → gray2
+NodeConnection:data:2:RETVAL:5:img
+NodeConnection:data:2:RETVAL:6:img_input
+NodeConnection:data:5:RETVAL:6:img_output
+
+# gray1 + gray2 → sub
+NodeConnection:data:4:img_output:7:img
+NodeConnection:data:4:img_output:8:img_input1
+NodeConnection:data:6:img_output:8:img_input2
+NodeConnection:data:7:RETVAL:8:img_output
+NodeConnection:data:8:img_output:11:image
+
+# sub → threshold
+NodeConnection:data:8:img_output:9:img
+NodeConnection:data:8:img_output:10:src
+NodeConnection:data:9:RETVAL:10:dst
+NodeConnection:data:10:dst:12:image
+NodeConnection:data:10:dst:13:image
+
+AnnotationsBegin
+AnnotationsEnd
+
+WorkspaceEnd: 1.0

--- a/SAMPLES/cv_pipeline_completo.wksp
+++ b/SAMPLES/cv_pipeline_completo.wksp
@@ -1,0 +1,89 @@
+
+WorkspaceBegin: 1.0
+
+VariablesBegin:
+VariablesEnd:
+
+# ─── Entrada ───────────────────────────────────────────────────
+Glyph:VGL_CL:vglLoadImage::localhost:1:80:200:: -filename 'files/images/01.png' -iscolor 1 -has_mipmap 0
+
+# ─── Converter para cinza ──────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:2:280:100::
+Glyph:VGL_CV:vglCvRgb2Gray::localhost:3:480:100::
+
+# ─── Inverter ──────────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:4:280:250::
+Glyph:VGL_CV:vglCvInvert::localhost:5:480:250::
+
+# ─── Blur na imagem cinza ──────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:6:280:400::
+Glyph:VGL_CV:vglCvBlurSq3::localhost:7:480:400::
+
+# ─── Dilate no blur ────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:8:680:400::
+Glyph:VGL_CV:vglCvDilate::localhost:9:880:400:: -convolution_window [1,1,1,1,1,1,1,1,1] -window_size_x 3 -window_size_y 3
+
+# ─── Erode no dilate ───────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:10:680:550::
+Glyph:VGL_CV:vglCvErode::localhost:11:880:550:: -convolution_window [1,1,1,1,1,1,1,1,1] -window_size_x 3 -window_size_y 3
+
+# ─── Max(blur, invertida) ──────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:12:680:250::
+Glyph:VGL_CV:vglCvMax::localhost:13:880:250::
+
+# ─── Threshold no max ──────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:14:1080:250::
+Glyph:VGL_CV:vglCvThreshold::localhost:15:1280:250:: -thresh 0.3 -top 1.0
+
+# ─── Saídas ────────────────────────────────────────────────────
+Glyph:VGL_CL:vglSaveImage::localhost:16:1100:100:: -filename 'out/cv_gray.png'
+Glyph:VGL_CL:vglSaveImage::localhost:17:1100:400:: -filename 'out/cv_morph.png'
+Glyph:VGL_CL:vglSaveImage::localhost:18:1500:250:: -filename 'out/cv_pipeline.png'
+Glyph:VGL_CL:ShowImage::localhost:19:1500:150::
+Glyph:VGL_CL:ShowImage::localhost:20:1500:400::
+
+# load → gray
+NodeConnection:data:1:RETVAL:2:img
+NodeConnection:data:1:RETVAL:3:img_input
+NodeConnection:data:2:RETVAL:3:img_output
+NodeConnection:data:3:img_output:16:image
+
+# gray → invert
+NodeConnection:data:3:img_output:4:img
+NodeConnection:data:3:img_output:5:img_input
+NodeConnection:data:4:RETVAL:5:img_output
+
+# gray → blur
+NodeConnection:data:3:img_output:6:img
+NodeConnection:data:3:img_output:7:img_input
+NodeConnection:data:6:RETVAL:7:img_output
+
+# blur → dilate
+NodeConnection:data:7:img_output:8:img
+NodeConnection:data:7:img_output:9:img_input
+NodeConnection:data:8:RETVAL:9:img_output
+
+# dilate → erode
+NodeConnection:data:9:img_output:10:img
+NodeConnection:data:9:img_output:11:img_input
+NodeConnection:data:10:RETVAL:11:img_output
+NodeConnection:data:11:img_output:17:image
+
+# blur + invert → max
+NodeConnection:data:7:img_output:12:img
+NodeConnection:data:7:img_output:13:img_input1
+NodeConnection:data:5:img_output:13:img_input2
+NodeConnection:data:12:RETVAL:13:img_output
+
+# max → threshold
+NodeConnection:data:13:img_output:14:img
+NodeConnection:data:13:img_output:15:src
+NodeConnection:data:14:RETVAL:15:dst
+NodeConnection:data:15:dst:18:image
+NodeConnection:data:15:dst:19:image
+NodeConnection:data:11:img_output:20:image
+
+AnnotationsBegin
+AnnotationsEnd
+
+WorkspaceEnd: 1.0

--- a/SAMPLES/fundus_cv.wksp
+++ b/SAMPLES/fundus_cv.wksp
@@ -1,161 +1,107 @@
-# VisionGL Visual Programming Workspace
-#
-# VisionGL workspace file (fundus_cv.wksp) - OpenCV version of fundus.wksp
-# Note: Reconstruct operation not available in OpenCV module, pipeline ends at Threshold
-#
 
 WorkspaceBegin: 1.0
 
 VariablesBegin:
-
-#
-# list of currently declared variables
-#
-
-width_size = 2342
-height_size = 1144
-
 VariablesEnd:
 
-#  Glyph 'Image load'
-Glyph:VGL_OPENCV:vglCvLoad2dImage::localhost:1:302:82:: -filename 'files/images/goodQuality/16_good.JPG' -iscolor 1 -has_mipmap 0
+# ─── Entrada ────────────────────────────────────────────────────────────────
+Glyph:VGL_CL:vglLoadImage::localhost:1:80:200:: -filename 'files/images/goodQuality/16_good.JPG' -iscolor 1 -has_mipmap 0
 
-#  Glyph 'Create Image Rgb2Gray'
-Glyph:VGL_OPENCV:vglCvCreateImage::localhost:2:562:122::
+# ─── Rgb2Gray ────────────────────────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:2:280:100::
+Glyph:VGL_CV:vglCvRgb2Gray::localhost:3:480:200::
 
-#  Glyph 'vglCvRgb2Gray'
-Glyph:VGL_OPENCV:vglCvRgb2Gray::localhost:3:382:182::
+# ─── Convolucao Gaussiana 1x51 ───────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:4:680:100::
+Glyph:VGL_CV:vglCvConvolution::localhost:5:880:200:: -convolution_window [0.00037832,0.00055477,0.00080091,0.00113832,0.00159279,0.00219416,0.00297573,0.00397312,0.00522256,0.0067585,0.00861055,0.01080005,0.01333629,0.0162128,0.01940418,0.02286371,0.02652237,0.0302895,0.0340554,0.03769589,0.04107865,0.04407096,0.04654821,0.04840248,0.04955031,0.04993894,0.04955031,0.04840248,0.04654821,0.04407096,0.04107865,0.03769589,0.0340554,0.0302895,0.02652237,0.02286371,0.01940418,0.0162128,0.01333629,0.01080005,0.00861055,0.0067585,0.00522256,0.00397312,0.00297573,0.00219416,0.00159279,0.00113832,0.00080091,0.00055477,0.00037832] -window_size_x 51 -window_size_y 1
 
-#  Glyph 'Create Image Convolution 1x51'
-Glyph:VGL_OPENCV:vglCvCreateImage::localhost:4:562:242::
+# ─── Convolucao Gaussiana 51x1 ───────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:6:1080:100::
+Glyph:VGL_CV:vglCvConvolution::localhost:7:1280:200:: -convolution_window [0.00037832,0.00055477,0.00080091,0.00113832,0.00159279,0.00219416,0.00297573,0.00397312,0.00522256,0.0067585,0.00861055,0.01080005,0.01333629,0.0162128,0.01940418,0.02286371,0.02652237,0.0302895,0.0340554,0.03769589,0.04107865,0.04407096,0.04654821,0.04840248,0.04955031,0.04993894,0.04955031,0.04840248,0.04654821,0.04407096,0.04107865,0.03769589,0.0340554,0.0302895,0.02652237,0.02286371,0.01940418,0.0162128,0.01333629,0.01080005,0.00861055,0.0067585,0.00522256,0.00397312,0.00297573,0.00219416,0.00159279,0.00113832,0.00080091,0.00055477,0.00037832] -window_size_x 1 -window_size_y 51
 
-#  Glyph 'vglCvConvolution 1x51'
-Glyph:VGL_OPENCV:vglCvConvolution::localhost:5:462:302:: -convolution_window ['0.00037832','0.00055477','0.00080091','0.00113832','0.00159279','0.00219416','0.00297573','0.00397312','0.00522256','0.0067585','0.00861055','0.01080005','0.01333629','0.0162128','0.01940418','0.02286371','0.02652237','0.0302895','0.0340554','0.03769589','0.04107865','0.04407096','0.04654821','0.04840248','0.04955031','0.04993894','0.04955031','0.04840248','0.04654821','0.04407096','0.04107865','0.03769589','0.0340554',0'0.0302895','0.02652237','0.02286371','0.01940418','0.0162128','0.01333629','0.01080005','0.00861055','0.0067585','0.00522256','0.00397312','0.00297573','0.00219416','0.00159279','0.00113832','0.00080091','0.00055477','0.00037832'] -windows 51 -windows 1
+# ─── Dilate 1x51 ────────────────────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:8:1480:100::
+Glyph:VGL_CV:vglCvDilate::localhost:9:1680:200:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 51 -window_size_y 1
 
-#  Glyph 'Create Image Convolution 51x1'
-Glyph:VGL_OPENCV:vglCvCreateImage::localhost:6:562:242::
+# ─── Dilate 51x1 ────────────────────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:10:1880:100::
+Glyph:VGL_CV:vglCvDilate::localhost:11:2080:200:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 1 -window_size_y 51
 
-#  Glyph 'vglCvConvolution 51x1'
-Glyph:VGL_OPENCV:vglCvConvolution::localhost:7:462:302:: -convolution_window ['0.00037832','0.00055477','0.00080091','0.00113832','0.00159279','0.00219416','0.00297573','0.00397312','0.00522256','0.0067585','0.00861055','0.01080005','0.01333629','0.0162128','0.01940418','0.02286371','0.02652237','0.0302895','0.0340554','0.03769589','0.04107865','0.04407096','0.04654821','0.04840248','0.04955031','0.04993894','0.04955031','0.04840248','0.04654821','0.04407096','0.04107865','0.03769589','0.0340554',0'0.0302895','0.02652237','0.02286371','0.01940418','0.0162128','0.01333629','0.01080005','0.00861055','0.0067585','0.00522256','0.00397312','0.00297573','0.00219416','0.00159279','0.00113832','0.00080091','0.00055477','0.00037832'] -windows 1 -windows 51
+# ─── Erode 1x51 ─────────────────────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:12:2280:100::
+Glyph:VGL_CV:vglCvErode::localhost:13:2480:200:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 1 -window_size_y 51
 
-#  Glyph 'Create Image Dilate 1x51'
-Glyph:VGL_OPENCV:vglCvCreateImage::localhost:8:562:242::
+# ─── Erode 51x1 ─────────────────────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:14:2680:100::
+Glyph:VGL_CV:vglCvErode::localhost:15:2880:200:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 51 -window_size_y 1
 
-#  Glyph 'vglCvDilate 1x51'
-Glyph:VGL_OPENCV:vglCvDilate::localhost:9:462:302:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 51 -window_size_y 1
+# ─── Sub (erode - conv) ──────────────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:16:3080:100::
+Glyph:VGL_CV:vglCvSub::localhost:17:3280:200::
 
-#  Glyph 'Create Image Dilate 51x1'
-Glyph:VGL_OPENCV:vglCvCreateImage::localhost:10:562:242::
+# ─── Threshold ───────────────────────────────────────────────────────────────
+Glyph:VGL_CL:vglCreateImage::localhost:18:3480:100::
+Glyph:VGL_CV:vglCvThreshold::localhost:19:3680:200:: -thresh 0.00784 -top 1.0
 
-#  Glyph 'vglCvDilate 51x1'
-Glyph:VGL_OPENCV:vglCvDilate::localhost:11:462:302:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 1 -window_size_y 51
+# ─── Saidas ──────────────────────────────────────────────────────────────────
+Glyph:VGL_CL:vglSaveImage::localhost:20:3900:50::  -filename 'out/artigo1/fundusCV_gray.png'
+Glyph:VGL_CL:vglSaveImage::localhost:21:3900:150:: -filename 'out/artigo1/fundusCV_conv.png'
+Glyph:VGL_CL:vglSaveImage::localhost:22:3900:250:: -filename 'out/artigo1/fundusCV_dilate.png'
+Glyph:VGL_CL:vglSaveImage::localhost:23:3900:350:: -filename 'out/artigo1/fundusCV_erode.png'
+Glyph:VGL_CL:vglSaveImage::localhost:24:3900:450:: -filename 'out/artigo1/fundusCV_sub.png'
+Glyph:VGL_CL:vglSaveImage::localhost:25:3900:550:: -filename 'out/artigo1/fundusCV_thresh.png'
 
-#  Glyph 'Create Image Erode 1x51'
-Glyph:VGL_OPENCV:vglCvCreateImage::localhost:12:562:242::
-
-#  Glyph 'vglCvErode 1x51'
-Glyph:VGL_OPENCV:vglCvErode::localhost:13:462:302:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 1 -window_size_y 51
-
-#  Glyph 'Create Image Erode 51x1'
-Glyph:VGL_OPENCV:vglCvCreateImage::localhost:14:562:242::
-
-#  Glyph 'vglCvErode 51x1'
-Glyph:VGL_OPENCV:vglCvErode::localhost:15:462:302:: -convolution_window [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] -window_size_x 51 -window_size_y 1
-
-#  Glyph 'Create Image Sub'
-Glyph:VGL_OPENCV:vglCvCreateImage::localhost:16:562:242::
-
-# Glyph 'vglCvSub'
-Glyph:VGL_OPENCV:vglCvSub::localhost:17:462:302::
-
-#  Glyph 'Create Image Threshold'
-Glyph:VGL_OPENCV:vglCvCreateImage::localhost:18:562:242::
-
-#  Glyph 'vglCvThreshold'
-Glyph:VGL_OPENCV:vglCvThreshold::localhost:19:462:302:: -thresh 0.00784 -top 1
-
-#  Glyph 'Image save Rgb2Gray'
-Glyph:VGL_OPENCV:vglCvSaveImage::localhost:22:882:362:: -filename 'out/artigo1/fundusRgb2gray_cv.png'
-
-#  Glyph 'Image save Convolution'
-Glyph:VGL_OPENCV:vglCvSaveImage::localhost:23:882:362:: -filename 'out/artigo1/fundusConvolution_cv.png'
-
-#  Glyph 'Image save Dilate'
-Glyph:VGL_OPENCV:vglCvSaveImage::localhost:24:882:362:: -filename 'out/artigo1/fundusDilate_cv.png'
-
-#  Glyph 'Image save Erode'
-Glyph:VGL_OPENCV:vglCvSaveImage::localhost:25:882:362:: -filename 'out/artigo1/fundusErode_cv.png'
-
-#  Glyph 'Image save Sub'
-Glyph:VGL_OPENCV:vglCvSaveImage::localhost:26:882:362:: -filename 'out/artigo1/fundusSub_cv.png'
-
-#  Glyph 'Image save Thresh'
-Glyph:VGL_OPENCV:vglCvSaveImage::localhost:27:882:362:: -filename 'out/artigo1/fundusThresh_cv.png'
-
-#  Connections 'Applying Rgb2Gray'
+# ─── load -> gray ────────────────────────────────────────────────────────────
 NodeConnection:data:1:RETVAL:2:img
 NodeConnection:data:1:RETVAL:3:img_input
 NodeConnection:data:2:RETVAL:3:img_output
+NodeConnection:data:3:img_output:20:image
 
-# Connections 'Save Rgb2Gray'
-NodeConnection:data:3:img_output:22:image
-
-#Connections 'Applying Convolution_1x51'
+# ─── gray -> conv 1x51 ──────────────────────────────────────────────────────
 NodeConnection:data:3:img_output:4:img
 NodeConnection:data:3:img_output:5:img_input
 NodeConnection:data:4:RETVAL:5:img_output
 
-#Connections 'Applying Convolution_51x1'
+# ─── conv 1x51 -> conv 51x1 ─────────────────────────────────────────────────
 NodeConnection:data:5:img_output:6:img
 NodeConnection:data:5:img_output:7:img_input
 NodeConnection:data:6:RETVAL:7:img_output
+NodeConnection:data:7:img_output:21:image
 
-#Connections 'Save Convolution'
-NodeConnection:data:7:img_output:23:image
-
-NodeConnection:data:7:img_output:17:img_input2
-
-#Connections 'Applying Dilate 1x51'
+# ─── conv 51x1 -> dilate 1x51 ───────────────────────────────────────────────
 NodeConnection:data:7:img_output:8:img
 NodeConnection:data:7:img_output:9:img_input
 NodeConnection:data:8:RETVAL:9:img_output
 
-#Connections 'Applying Dilate 51x1'
+# ─── dilate 1x51 -> dilate 51x1 ─────────────────────────────────────────────
 NodeConnection:data:9:img_output:10:img
 NodeConnection:data:9:img_output:11:img_input
 NodeConnection:data:10:RETVAL:11:img_output
+NodeConnection:data:11:img_output:22:image
 
-#Connections 'Save Dilate'
-NodeConnection:data:11:img_output:24:image
-
-#Connections 'Applying Erode 1x51'
+# ─── dilate 51x1 -> erode 1x51 ──────────────────────────────────────────────
 NodeConnection:data:11:img_output:12:img
 NodeConnection:data:11:img_output:13:img_input
 NodeConnection:data:12:RETVAL:13:img_output
 
-# Connections 'Applying Erode 51x1'
+# ─── erode 1x51 -> erode 51x1 ───────────────────────────────────────────────
 NodeConnection:data:13:img_output:14:img
 NodeConnection:data:13:img_output:15:img_input
 NodeConnection:data:14:RETVAL:15:img_output
+NodeConnection:data:15:img_output:23:image
 
-#Connections 'Save Erode'
-NodeConnection:data:15:img_output:25:image
-
-# Connections 'Applying Sub'
+# ─── sub: erode(input1) - conv(input2) ──────────────────────────────────────
 NodeConnection:data:15:img_output:16:img
 NodeConnection:data:15:img_output:17:img_input1
+NodeConnection:data:7:img_output:17:img_input2
 NodeConnection:data:16:RETVAL:17:img_output
+NodeConnection:data:17:img_output:24:image
 
-#Connections 'Save Sub'
-NodeConnection:data:17:img_output:26:image
-
-# Connections 'Applying Thresh'
+# ─── threshold ───────────────────────────────────────────────────────────────
 NodeConnection:data:17:img_output:18:img
 NodeConnection:data:17:img_output:19:src
 NodeConnection:data:18:RETVAL:19:dst
-
-# Connections 'Save Thresh'
-NodeConnection:data:19:dst:27:image
+NodeConnection:data:19:dst:25:image
 
 AnnotationsBegin
 AnnotationsEnd

--- a/execWorkflow.py
+++ b/execWorkflow.py
@@ -1233,4 +1233,113 @@ def execWorkflow(workspace, is_subworkflow=False, parent_workflow_id=None, proce
           GlyphExecutedUpdate(vGlyph.glyph_id, vglClFuzzyStdErode_img_output, workspace)
 
 
+        elif vGlyph.func == 'vglCvBlurSq3':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvBlurSq3_img_input = getImageInputByIdName(vGlyph.glyph_id, 'img_input', workspace)
+          vglCvBlurSq3_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvBlurSq3(vglCvBlurSq3_img_input, vglCvBlurSq3_img_output)
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvBlurSq3_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvConvolution':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvConvolution_img_input = getImageInputByIdName(vGlyph.glyph_id, 'img_input', workspace)
+          vglCvConvolution_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvConvolution(vglCvConvolution_img_input, vglCvConvolution_img_output, tratnum(vGlyph.lst_par[0].getValue()), np.uint32(vGlyph.lst_par[1].getValue()), np.uint32(vGlyph.lst_par[2].getValue()))
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvConvolution_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvCopy':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvCopy_img_input = getImageInputByIdName(vGlyph.glyph_id, 'img_input', workspace)
+          vglCvCopy_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvCopy(vglCvCopy_img_input, vglCvCopy_img_output)
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvCopy_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvDilate':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvDilate_img_input = getImageInputByIdName(vGlyph.glyph_id, 'img_input', workspace)
+          vglCvDilate_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvDilate(vglCvDilate_img_input, vglCvDilate_img_output, tratnum(vGlyph.lst_par[0].getValue()), np.uint32(vGlyph.lst_par[1].getValue()), np.uint32(vGlyph.lst_par[2].getValue()))
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvDilate_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvErode':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvErode_img_input = getImageInputByIdName(vGlyph.glyph_id, 'img_input', workspace)
+          vglCvErode_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvErode(vglCvErode_img_input, vglCvErode_img_output, tratnum(vGlyph.lst_par[0].getValue()), np.uint32(vGlyph.lst_par[1].getValue()), np.uint32(vGlyph.lst_par[2].getValue()))
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvErode_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvInvert':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvInvert_img_input = getImageInputByIdName(vGlyph.glyph_id, 'img_input', workspace)
+          vglCvInvert_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvInvert(vglCvInvert_img_input, vglCvInvert_img_output)
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvInvert_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvMax':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvMax_img_input1 = getImageInputByIdName(vGlyph.glyph_id, 'img_input1', workspace)
+          vglCvMax_img_input2 = getImageInputByIdName(vGlyph.glyph_id, 'img_input2', workspace)
+          vglCvMax_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvMax(vglCvMax_img_input1, vglCvMax_img_input2, vglCvMax_img_output)
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvMax_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvMin':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvMin_img_input1 = getImageInputByIdName(vGlyph.glyph_id, 'img_input1', workspace)
+          vglCvMin_img_input2 = getImageInputByIdName(vGlyph.glyph_id, 'img_input2', workspace)
+          vglCvMin_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvMin(vglCvMin_img_input1, vglCvMin_img_input2, vglCvMin_img_output)
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvMin_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvRgb2Gray':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvRgb2Gray_img_input = getImageInputByIdName(vGlyph.glyph_id, 'img_input', workspace)
+          vglCvRgb2Gray_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvRgb2Gray(vglCvRgb2Gray_img_input, vglCvRgb2Gray_img_output)
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvRgb2Gray_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvSub':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvSub_img_input1 = getImageInputByIdName(vGlyph.glyph_id, 'img_input1', workspace)
+          vglCvSub_img_input2 = getImageInputByIdName(vGlyph.glyph_id, 'img_input2', workspace)
+          vglCvSub_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvSub(vglCvSub_img_input1, vglCvSub_img_input2, vglCvSub_img_output)
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvSub_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvSum':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvSum_img_input1 = getImageInputByIdName(vGlyph.glyph_id, 'img_input1', workspace)
+          vglCvSum_img_input2 = getImageInputByIdName(vGlyph.glyph_id, 'img_input2', workspace)
+          vglCvSum_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvSum(vglCvSum_img_input1, vglCvSum_img_input2, vglCvSum_img_output)
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvSum_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvSwapRgb':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvSwapRgb_img_input = getImageInputByIdName(vGlyph.glyph_id, 'img_input', workspace)
+          vglCvSwapRgb_img_output = getImageInputByIdName(vGlyph.glyph_id, 'img_output', workspace)
+          vglCvSwapRgb(vglCvSwapRgb_img_input, vglCvSwapRgb_img_output)
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvSwapRgb_img_output, workspace)
+
+        elif vGlyph.func == 'vglCvThreshold':
+          print("-------------------------------------------------")
+          print("A função " + vGlyph.func + " está sendo executada")
+          vglCvThreshold_src = getImageInputByIdName(vGlyph.glyph_id, 'src', workspace)
+          vglCvThreshold_dst = getImageInputByIdName(vGlyph.glyph_id, 'dst', workspace)
+          vglCvThreshold(vglCvThreshold_src, vglCvThreshold_dst, np.float32(vGlyph.lst_par[0].getValue()), np.float32(vGlyph.lst_par[1].getValue()))
+          GlyphExecutedUpdate(vGlyph.glyph_id, vglCvThreshold_dst, workspace)
+
+
 execWorkflow(workspace)

--- a/gui/app.py
+++ b/gui/app.py
@@ -70,7 +70,7 @@ def run():
     set_language(_cfg.get("language", "pt"))
 
     from gui.canvas        import setup_canvas, flush_status_queue, bind_canvas_handlers, flush_node_previews
-    from gui.sidebar_glyphs import setup_sidebar, bind_sidebar_handlers
+    from gui.sidebar_glyphs import setup_sidebar
     from gui.toolbar       import setup_menu_bar
     from gui.log_panel     import setup_log_panel, flush_log_buffer
     from gui.image_preview import setup_texture_registry, flush_preview_queue
@@ -103,7 +103,6 @@ def run():
 
     dpg.set_primary_window(1, True)
     bind_canvas_handlers()
-    bind_sidebar_handlers()
     dpg.show_viewport()
 
     _last_title = ""

--- a/gui/glyph_registry.py
+++ b/gui/glyph_registry.py
@@ -103,6 +103,7 @@ CATEGORY_COLORS: dict[str, tuple[int, int, int]] = {
     "Fuzzy 2D":    (125, 65,  55),
     "Fuzzy 3D":    (105, 50,  50),
     "Procedures":  (30,  85,  90),
+    "CV":          (30,  110, 100),
 }
 
 
@@ -447,6 +448,90 @@ GLYPH_REGISTRY: dict[str, GlyphDef] = {
         params=[ParamDef("thresh","float", default="0.5")],
     ),
 
+    # ── CV (OpenCV) ───────────────────────────────────────────────────────────
+
+    "vglCvBlurSq3": GlyphDef(
+        func="vglCvBlurSq3", label="vglCvBlurSq3", category="CV",
+        ports=[PortDef("img_input","input"), PortDef("img_output","input"),
+               PortDef("img_output","output")],
+        params=[], library="VGL_CV",
+    ),
+    "vglCvConvolution": GlyphDef(
+        func="vglCvConvolution", label="vglCvConvolution", category="CV",
+        ports=[PortDef("img_input","input"), PortDef("img_output","input"),
+               PortDef("img_output","output")],
+        params=_morph_params_2d(), library="VGL_CV",
+    ),
+    "vglCvCopy": GlyphDef(
+        func="vglCvCopy", label="vglCvCopy", category="CV",
+        ports=[PortDef("img_input","input"), PortDef("img_output","input"),
+               PortDef("img_output","output")],
+        params=[], library="VGL_CV",
+    ),
+    "vglCvDilate": GlyphDef(
+        func="vglCvDilate", label="vglCvDilate", category="CV",
+        ports=[PortDef("img_input","input"), PortDef("img_output","input"),
+               PortDef("img_output","output")],
+        params=_morph_params_2d(), library="VGL_CV",
+    ),
+    "vglCvErode": GlyphDef(
+        func="vglCvErode", label="vglCvErode", category="CV",
+        ports=[PortDef("img_input","input"), PortDef("img_output","input"),
+               PortDef("img_output","output")],
+        params=_morph_params_2d(), library="VGL_CV",
+    ),
+    "vglCvInvert": GlyphDef(
+        func="vglCvInvert", label="vglCvInvert", category="CV",
+        ports=[PortDef("img_input","input"), PortDef("img_output","input"),
+               PortDef("img_output","output")],
+        params=[], library="VGL_CV",
+    ),
+    "vglCvMax": GlyphDef(
+        func="vglCvMax", label="vglCvMax", category="CV",
+        ports=[PortDef("img_input1","input"), PortDef("img_input2","input"),
+               PortDef("img_output","input"), PortDef("img_output","output")],
+        params=[], library="VGL_CV",
+    ),
+    "vglCvMin": GlyphDef(
+        func="vglCvMin", label="vglCvMin", category="CV",
+        ports=[PortDef("img_input1","input"), PortDef("img_input2","input"),
+               PortDef("img_output","input"), PortDef("img_output","output")],
+        params=[], library="VGL_CV",
+    ),
+    "vglCvRgb2Gray": GlyphDef(
+        func="vglCvRgb2Gray", label="vglCvRgb2Gray", category="CV",
+        ports=[PortDef("img_input","input"), PortDef("img_output","input"),
+               PortDef("img_output","output")],
+        params=[], library="VGL_CV",
+    ),
+    "vglCvSub": GlyphDef(
+        func="vglCvSub", label="vglCvSub", category="CV",
+        ports=[PortDef("img_input1","input"), PortDef("img_input2","input"),
+               PortDef("img_output","input"), PortDef("img_output","output")],
+        params=[], library="VGL_CV",
+    ),
+    "vglCvSum": GlyphDef(
+        func="vglCvSum", label="vglCvSum", category="CV",
+        ports=[PortDef("img_input1","input"), PortDef("img_input2","input"),
+               PortDef("img_output","input"), PortDef("img_output","output")],
+        params=[], library="VGL_CV",
+    ),
+    "vglCvSwapRgb": GlyphDef(
+        func="vglCvSwapRgb", label="vglCvSwapRgb", category="CV",
+        ports=[PortDef("img_input","input"), PortDef("img_output","input"),
+               PortDef("img_output","output")],
+        params=[], library="VGL_CV",
+    ),
+    "vglCvThreshold": GlyphDef(
+        func="vglCvThreshold", label="vglCvThreshold", category="CV",
+        ports=[PortDef("src","input"), PortDef("dst","input"),
+               PortDef("dst","output")],
+        params=[
+            ParamDef("thresh", "float", default="0.5"),
+            ParamDef("top",    "float", default="1.0"),
+        ], library="VGL_CV",
+    ),
+
     # ── Fuzzy 2D ─────────────────────────────────────────────────────────────
 
     "vglClFuzzyAlgDilate":     _fuzzy_2d("vglClFuzzyAlgDilate"),
@@ -500,4 +585,5 @@ CATEGORIES: list[str] = [
     "3D",
     "Fuzzy 2D",
     "Fuzzy 3D",
+    "CV",
 ]

--- a/gui/glyph_registry.py
+++ b/gui/glyph_registry.py
@@ -574,6 +574,7 @@ GLYPH_REGISTRY: dict[str, GlyphDef] = {
 # Ordem de exibição das categorias na sidebar
 CATEGORIES: list[str] = [
     "Procedures",
+    "CV",
     "I/O",
     "Allocation",
     "Color",
@@ -585,5 +586,4 @@ CATEGORIES: list[str] = [
     "3D",
     "Fuzzy 2D",
     "Fuzzy 3D",
-    "CV",
 ]

--- a/gui/i18n.py
+++ b/gui/i18n.py
@@ -35,11 +35,11 @@ _STRINGS: dict[str, dict[str, str]] = {
 
     # ── Menu View ────────────────────────────────────────────────────────────
     "menu_view":    {"pt": "Exibir",             "en": "View"},
-    "layout_lr":    {"pt": "Layout: E→D   Ctrl+L",         "en": "Layout: L→R  Ctrl+L"},
-    "layout_tb":    {"pt": "Layout: C→B",                  "en": "Layout: T→B"},
-    "fit_screen":   {"pt": "Ajustar à Tela  Ctrl+Shift+F", "en": "Fit to Screen  Ctrl+Shift+F"},
-    "toggle_log":        {"pt": "Alternar Log",                  "en": "Toggle Log"},
-    "toggle_cat_colors": {"pt": "Alternar Cores por Categoria",  "en": "Toggle Category Colors"},
+    "layout_lr":    {"pt": "Layout: E->D   Ctrl+L",        "en": "Layout: L->R  Ctrl+L"},
+    "layout_tb":    {"pt": "Layout: C->B",                 "en": "Layout: T->B"},
+    "fit_screen":   {"pt": "Ajustar Tela  Ctrl+Shift+F",   "en": "Fit to Screen  Ctrl+Shift+F"},
+    "toggle_log":        {"pt": "Alternar Log",                 "en": "Toggle Log"},
+    "toggle_cat_colors": {"pt": "Alternar Cores por Categoria", "en": "Toggle Category Colors"},
 
     # ── Menu Help ────────────────────────────────────────────────────────────
     "menu_help":        {"pt": "Ajuda",                    "en": "Help"},
@@ -75,7 +75,7 @@ _STRINGS: dict[str, dict[str, str]] = {
     "export_canvas_error":  {"pt": "[export] Erro ao exportar canvas: {err}", "en": "[export] Error exporting canvas: {err}"},
     "export_canvas_no_tool":{"pt": "[export] Nenhuma ferramenta de captura disponível (mss, scrot ou ImageMagick).",
                               "en": "[export] No screenshot tool available (mss, scrot, or ImageMagick)."},
-    "export_canvas_dialog": {"pt": "Exportar Canvas — Salvar PNG", "en": "Export Canvas — Save PNG"},
+    "export_canvas_dialog": {"pt": "Exportar Canvas - Salvar PNG", "en": "Export Canvas - Save PNG"},
 
     # ── Log panel ────────────────────────────────────────────────────────────
     "exec_log":     {"pt": "Log de execução",    "en": "Execution Log"},
@@ -109,8 +109,8 @@ _STRINGS: dict[str, dict[str, str]] = {
     # ── Runner ───────────────────────────────────────────────────────────────
     "runner_running":  {"pt": "[runner] Execução já em andamento.",
                         "en": "[runner] Execution already in progress."},
-    "runner_empty":    {"pt": "[runner] Canvas vazio — nada para executar.",
-                        "en": "[runner] Canvas is empty — nothing to execute."},
+    "runner_empty":    {"pt": "[runner] Canvas vazio - nada para executar.",
+                        "en": "[runner] Canvas is empty - nothing to execute."},
     "runner_starting": {"pt": "\n[runner] Iniciando execução em {device}...\n",
                         "en": "\n[runner] Starting execution on {device}...\n"},
     "runner_error":    {"pt": "[runner] ERRO ao iniciar processo: {err}",
@@ -164,6 +164,7 @@ _STRINGS: dict[str, dict[str, str]] = {
     "cat_3d":         {"pt": "3D",               "en": "3D"},
     "cat_fuzzy2d":    {"pt": "Fuzzy 2D",         "en": "Fuzzy 2D"},
     "cat_fuzzy3d":    {"pt": "Fuzzy 3D",         "en": "Fuzzy 3D"},
+    "cat_cv":         {"pt": "CV (OpenCV)",      "en": "CV (OpenCV)"},
 
     # ── Status bar ───────────────────────────────────────────────────────────────
     "status_nodes":  {"pt": "Nós",     "en": "Nodes"},
@@ -189,6 +190,7 @@ _CATEGORY_KEY: dict[str, str] = {
     "3D":          "cat_3d",
     "Fuzzy 2D":    "cat_fuzzy2d",
     "Fuzzy 3D":    "cat_fuzzy3d",
+    "CV":          "cat_cv",
 }
 
 

--- a/gui/sidebar_glyphs.py
+++ b/gui/sidebar_glyphs.py
@@ -7,15 +7,6 @@ from gui.i18n import t, cat_label
 _func_button_tags: dict[str, int] = {}
 _search_tag: int = 0   # inicializado em setup_sidebar (após create_context)
 
-# ---------------------------------------------------------------------------
-# Drag-and-drop state
-# ---------------------------------------------------------------------------
-_drag_state: dict = {
-    "active":     False,
-    "func":       None,
-    "label_tag":  0,     # tag da floating window (0 = não existe)
-}
-
 
 def setup_sidebar():
     global _search_tag
@@ -60,7 +51,6 @@ def setup_sidebar():
                     tag=btn_tag,
                     width=-1,
                     callback=_make_add_callback(glyph_def.func),
-                    # mouse_down_callback used for drag detection via item handler below
                 )
 
 
@@ -96,133 +86,3 @@ def _on_search(sender, value: str):
             dpg.show_item(btn_tag)
         else:
             dpg.hide_item(btn_tag)
-
-
-# ---------------------------------------------------------------------------
-# Drag-and-drop helpers
-# ---------------------------------------------------------------------------
-
-def _make_drag_start_callback(func: str):
-    """Retorna callback de mouse_down que inicia o drag de um glyph."""
-    def _cb(sender, app_data):
-        # app_data for mouse_down = mouse button index (0 = left)
-        if app_data != 0:
-            return
-        _start_drag(func)
-    return _cb
-
-
-def _start_drag(func: str):
-    """Inicia o estado de drag e cria a floating label."""
-    global _drag_state
-    if _drag_state["active"]:
-        return  # já está em drag
-
-    glyph_def = GLYPH_REGISTRY.get(func)
-    label_text = glyph_def.label if glyph_def else func
-
-    mx, my = dpg.get_mouse_pos(local=False)
-
-    win_tag = dpg.generate_uuid()
-    dpg.add_window(
-        tag=win_tag,
-        pos=[int(mx) + 12, int(my) + 12],
-        width=160,
-        height=28,
-        no_title_bar=True,
-        no_resize=True,
-        no_move=True,
-        no_scrollbar=True,
-        no_close=True,
-        no_background=False,
-    )
-    dpg.add_text(f"+ {label_text}", parent=win_tag)
-
-    _drag_state["active"]    = True
-    _drag_state["func"]      = func
-    _drag_state["label_tag"] = win_tag
-
-
-def _cancel_drag():
-    """Cancela o drag e destrói a floating label."""
-    global _drag_state
-    if _drag_state["label_tag"] and dpg.does_item_exist(_drag_state["label_tag"]):
-        dpg.delete_item(_drag_state["label_tag"])
-    _drag_state["active"]    = False
-    _drag_state["func"]      = None
-    _drag_state["label_tag"] = 0
-
-
-def _on_drag_move(sender, app_data):
-    """Atualiza posição da floating label enquanto o drag está ativo."""
-    if not _drag_state["active"]:
-        return
-    win_tag = _drag_state["label_tag"]
-    if not win_tag or not dpg.does_item_exist(win_tag):
-        return
-    mx, my = dpg.get_mouse_pos(local=False)
-    dpg.set_item_pos(win_tag, [int(mx) + 12, int(my) + 12])
-
-
-def _on_drag_release(sender, app_data):
-    """Finaliza o drag: se o mouse estiver sobre canvas_win, adiciona o glyph."""
-    if not _drag_state["active"]:
-        return
-
-    func = _drag_state["func"]
-    _cancel_drag()
-
-    if func is None:
-        return
-
-    # Verifica se o mouse está sobre o canvas_win
-    if not dpg.does_item_exist("canvas_win"):
-        return
-    if not dpg.is_item_hovered("canvas_win"):
-        return
-
-    # Calcula posição relativa ao canvas_win
-    mx, my = dpg.get_mouse_pos(local=False)
-    try:
-        rect_min = dpg.get_item_rect_min("canvas_win")
-        cx = mx - rect_min[0]
-        cy = my - rect_min[1]
-    except Exception:
-        try:
-            pos = dpg.get_item_pos("canvas_win")
-            cx = mx - pos[0]
-            cy = my - pos[1]
-        except Exception:
-            cx, cy = mx, my
-
-    active_proc = APP_STATE.get("active_procedure")
-    if active_proc:
-        from gui.procedure_canvas import add_glyph_to_procedure
-        add_glyph_to_procedure(active_proc, func, pos_x=cx, pos_y=cy)
-    else:
-        from gui.canvas import add_glyph_to_canvas
-        add_glyph_to_canvas(func, pos_x=cx, pos_y=cy)
-
-
-def bind_sidebar_handlers():
-    """Registra handlers globais de mouse para drag-and-drop da sidebar.
-
-    Deve ser chamado de app.py após bind_canvas_handlers(), fora de qualquer
-    contexto de janela/widget.
-    """
-    # Registra mouse_down em cada botão de função via item_handler_registry
-    for func, btn_tag in _func_button_tags.items():
-        if not dpg.does_item_exist(btn_tag):
-            continue
-        registry_tag = dpg.generate_uuid()
-        with dpg.item_handler_registry(tag=registry_tag):
-            dpg.add_item_clicked_handler(
-                button=0,
-                callback=_make_drag_start_callback(func),
-            )
-        dpg.bind_item_handler_registry(btn_tag, registry_tag)
-
-    # Handlers globais de mouse para mover e soltar
-    with dpg.handler_registry():
-        dpg.add_mouse_move_handler(callback=_on_drag_move)
-        dpg.add_mouse_release_handler(callback=_on_drag_release)

--- a/gui/toolbar.py
+++ b/gui/toolbar.py
@@ -40,20 +40,13 @@ _EXAMPLES: dict[str, list[tuple[str, str]]] = {
         ("CV Morfologia - Dilate + Erode",       "SAMPLES/cv_morfologia.wksp"),
         ("CV Operacoes - Sub + Threshold",       "SAMPLES/cv_operacoes.wksp"),
         ("CV Pipeline Completo",                 "SAMPLES/cv_pipeline_completo.wksp"),
+        ("Fundus CV - Retina (OpenCV)",          "SAMPLES/fundus_cv.wksp"),
     ],
 }
 
 def _new_tag() -> int:
     return dpg.generate_uuid()
 
-
-def _get_ordered_examples() -> dict:
-    """Returns _EXAMPLES ordered by saved config, new categories appended at end."""
-    from gui.config import load_config
-    saved = load_config().get("examples_order", list(_EXAMPLES.keys()))
-    order = [k for k in saved if k in _EXAMPLES]
-    order += [k for k in _EXAMPLES if k not in order]
-    return {k: _EXAMPLES[k] for k in order}
 
 
 def _populate_recent_menu():
@@ -111,7 +104,7 @@ def setup_menu_bar():
                               callback=_stop)
 
         with dpg.menu(label=t("menu_examples")):
-            for category, examples in _get_ordered_examples().items():
+            for category, examples in _EXAMPLES.items():
                 with dpg.menu(label=category):
                     for label, rel_path in examples:
                         abs_path = os.path.join(_PROJECT_ROOT, rel_path)
@@ -125,8 +118,6 @@ def setup_menu_bar():
                                 label=f"{label}  {t('not_found')}",
                                 enabled=False,
                             )
-            dpg.add_separator()
-            dpg.add_menu_item(label="Organizar categorias...", callback=_open_examples_order_dialog)
 
         with dpg.menu(label=t("menu_view")):
             dpg.add_menu_item(label=t("layout_lr"),
@@ -217,74 +208,6 @@ def _make_example_callback(abs_path: str):
             _load_example(abs_path)
     return _cb
 
-
-def _open_examples_order_dialog():
-    WIN = "examples_order_win"
-    if dpg.does_item_exist(WIN):
-        dpg.focus_item(WIN)
-        return
-
-    from gui.config import load_config, save_config
-
-    saved = load_config().get("examples_order", list(_EXAMPLES.keys()))
-    order: list[str] = [k for k in saved if k in _EXAMPLES]
-    order += [k for k in _EXAMPLES if k not in order]
-
-    list_tag = dpg.generate_uuid()
-
-    def _rebuild():
-        dpg.delete_item(list_tag, children_only=True)
-        for i, cat in enumerate(order):
-            row = dpg.add_group(parent=list_tag, horizontal=True)
-            sel = dpg.add_selectable(
-                label=f"  {i + 1:>2}.  {cat}",
-                parent=row,
-                height=28,
-                width=260,
-            )
-            # Drag source: carries the index of the dragged item
-            with dpg.drag_payload(parent=sel, drag_data=i, payload_type="EXAMPLE_CAT"):
-                dpg.add_text(f"Movendo: {cat}")
-
-            # Drop target: reorders when another item is dropped here
-            def _make_drop(target_idx: int):
-                def _cb(_sender, app_data):
-                    src = app_data
-                    if src == target_idx:
-                        return
-                    moved = order.pop(src)
-                    order.insert(target_idx, moved)
-                    _rebuild()
-                return _cb
-
-            dpg.set_item_drop_callback(sel, _make_drop(i))
-
-    def _save():
-        cfg = load_config()
-        cfg["examples_order"] = order
-        save_config(cfg)
-        dpg.delete_item(WIN)
-        os.execv(sys.executable, [sys.executable] + sys.argv)
-
-    with dpg.window(
-        label="Organizar categorias de Exemplos",
-        tag=WIN, modal=True,
-        width=320, height=430,
-        pos=[500, 200],
-        no_resize=True,
-    ):
-        dpg.add_text("Arraste para reordenar:")
-        dpg.add_separator()
-        with dpg.child_window(tag=list_tag, height=330, border=True):
-            pass
-        _rebuild()
-        dpg.add_separator()
-        with dpg.group(horizontal=True):
-            dpg.add_button(label="Salvar e Reiniciar", width=160, callback=_save)
-            dpg.add_button(
-                label="Cancelar", width=100,
-                callback=lambda: dpg.delete_item(WIN),
-            )
 
 
 def _load_example(abs_path: str):

--- a/gui/toolbar.py
+++ b/gui/toolbar.py
@@ -35,10 +35,25 @@ _EXAMPLES: dict[str, list[tuple[str, str]]] = {
         ("GrayscaleConvert (procedure)",         "SAMPLES/procedures/exemplo_procedure_gui.wksp"),
         ("Demo Fundus (procedure)",              "SAMPLES/procedures/tcc/demo_fundus.wksp"),
     ],
+    "CV (OpenCV)": [
+        ("CV Basico - Gray + Blur",              "SAMPLES/cv_basico.wksp"),
+        ("CV Morfologia - Dilate + Erode",       "SAMPLES/cv_morfologia.wksp"),
+        ("CV Operacoes - Sub + Threshold",       "SAMPLES/cv_operacoes.wksp"),
+        ("CV Pipeline Completo",                 "SAMPLES/cv_pipeline_completo.wksp"),
+    ],
 }
 
 def _new_tag() -> int:
     return dpg.generate_uuid()
+
+
+def _get_ordered_examples() -> dict:
+    """Returns _EXAMPLES ordered by saved config, new categories appended at end."""
+    from gui.config import load_config
+    saved = load_config().get("examples_order", list(_EXAMPLES.keys()))
+    order = [k for k in saved if k in _EXAMPLES]
+    order += [k for k in _EXAMPLES if k not in order]
+    return {k: _EXAMPLES[k] for k in order}
 
 
 def _populate_recent_menu():
@@ -96,7 +111,7 @@ def setup_menu_bar():
                               callback=_stop)
 
         with dpg.menu(label=t("menu_examples")):
-            for category, examples in _EXAMPLES.items():
+            for category, examples in _get_ordered_examples().items():
                 with dpg.menu(label=category):
                     for label, rel_path in examples:
                         abs_path = os.path.join(_PROJECT_ROOT, rel_path)
@@ -110,6 +125,8 @@ def setup_menu_bar():
                                 label=f"{label}  {t('not_found')}",
                                 enabled=False,
                             )
+            dpg.add_separator()
+            dpg.add_menu_item(label="Organizar categorias...", callback=_open_examples_order_dialog)
 
         with dpg.menu(label=t("menu_view")):
             dpg.add_menu_item(label=t("layout_lr"),
@@ -199,6 +216,75 @@ def _make_example_callback(abs_path: str):
         else:
             _load_example(abs_path)
     return _cb
+
+
+def _open_examples_order_dialog():
+    WIN = "examples_order_win"
+    if dpg.does_item_exist(WIN):
+        dpg.focus_item(WIN)
+        return
+
+    from gui.config import load_config, save_config
+
+    saved = load_config().get("examples_order", list(_EXAMPLES.keys()))
+    order: list[str] = [k for k in saved if k in _EXAMPLES]
+    order += [k for k in _EXAMPLES if k not in order]
+
+    list_tag = dpg.generate_uuid()
+
+    def _rebuild():
+        dpg.delete_item(list_tag, children_only=True)
+        for i, cat in enumerate(order):
+            row = dpg.add_group(parent=list_tag, horizontal=True)
+            sel = dpg.add_selectable(
+                label=f"  {i + 1:>2}.  {cat}",
+                parent=row,
+                height=28,
+                width=260,
+            )
+            # Drag source: carries the index of the dragged item
+            with dpg.drag_payload(parent=sel, drag_data=i, payload_type="EXAMPLE_CAT"):
+                dpg.add_text(f"Movendo: {cat}")
+
+            # Drop target: reorders when another item is dropped here
+            def _make_drop(target_idx: int):
+                def _cb(_sender, app_data):
+                    src = app_data
+                    if src == target_idx:
+                        return
+                    moved = order.pop(src)
+                    order.insert(target_idx, moved)
+                    _rebuild()
+                return _cb
+
+            dpg.set_item_drop_callback(sel, _make_drop(i))
+
+    def _save():
+        cfg = load_config()
+        cfg["examples_order"] = order
+        save_config(cfg)
+        dpg.delete_item(WIN)
+        os.execv(sys.executable, [sys.executable] + sys.argv)
+
+    with dpg.window(
+        label="Organizar categorias de Exemplos",
+        tag=WIN, modal=True,
+        width=320, height=430,
+        pos=[500, 200],
+        no_resize=True,
+    ):
+        dpg.add_text("Arraste para reordenar:")
+        dpg.add_separator()
+        with dpg.child_window(tag=list_tag, height=330, border=True):
+            pass
+        _rebuild()
+        dpg.add_separator()
+        with dpg.group(horizontal=True):
+            dpg.add_button(label="Salvar e Reiniciar", width=160, callback=_save)
+            dpg.add_button(
+                label="Cancelar", width=100,
+                callback=lambda: dpg.delete_item(WIN),
+            )
 
 
 def _load_example(abs_path: str):


### PR DESCRIPTION
## Summary
- Registra 13 funções CV (VGL_CV) no glyph registry com categoria própria
- Adiciona handlers de execução para todas as funções CV em `execWorkflow.py`
- Categoria CV aparece no topo da sidebar (após Procedures)
- Cria 5 workflows de exemplo CV: basico, morfologia, operacoes, pipeline completo e fundus retina
- Adiciona grupo "CV (OpenCV)" no menu Exemplos
- Corrige chars não-ASCII (→, —) que apareciam como ? nos menus do DPG
- Remove código morto de drag-and-drop da sidebar

