### PR TITLE
feat(bench): adicionar execBench.py para benchmark de funções VGL

### DIFF
--- a/execBench.py
+++ b/execBench.py
@@ -15,6 +15,32 @@ import sys
 import re
 import csv
 import os
+from datetime import datetime
+
+
+def get_image_info(workflow):
+    """Parseia o .wksp e retorna (path, WxH) da primeira imagem de entrada."""
+    img_path = None
+    try:
+        with open(workflow) as f:
+            for line in f:
+                m = re.search(r"-filename '([^']+)'", line)
+                if m and line.strip().startswith('Glyph:'):
+                    img_path = m.group(1)
+                    break
+    except OSError:
+        return None, None
+
+    if not img_path or not os.path.isfile(img_path):
+        return img_path, None
+
+    try:
+        from PIL import Image
+        with Image.open(img_path) as img:
+            w, h = img.size
+        return img_path, f"{w}×{h}"
+    except Exception:
+        return img_path, None
 
 
 def run_bench(workflow, n, device):
@@ -39,10 +65,15 @@ def run_bench(workflow, n, device):
     return timings
 
 
-def print_table(results, n):
+def print_table(results, n, workflow, device_label):
     devices = list(results.keys())
     all_funcs = list(dict.fromkeys(f for d in devices for f in results[d]))
     n_ops = len(all_funcs)
+
+    img_path, img_dims = get_image_info(workflow)
+    dims_str = f" ({img_dims} px)" if img_dims else ""
+    img_str  = f"{img_path}{dims_str}" if img_path else "—"
+    now      = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     col_w = 16
     width = 38 + col_w * len(devices)
@@ -50,6 +81,10 @@ def print_table(results, n):
     header = f"{'Operação':<38}" + col_header
 
     print(f"\nBenchmark — {n} iterações × {n_ops} operações")
+    print(f"Workflow : {workflow}")
+    print(f"Imagem   : {img_str}")
+    print(f"Device   : {device_label}")
+    print(f"Data/hora: {now}")
     print("─" * width)
     print(header)
     print("─" * width)
@@ -103,7 +138,7 @@ def main():
     parser.add_argument('--device', default='GPU', choices=['GPU', 'CPU', 'BOTH'],
                         help='Device a usar (padrão: GPU)')
     parser.add_argument('--csv', metavar='FILE',
-                        help='Salvar resultado em CSV')
+                        help='Caminho do CSV de saída (padrão: out/<workflow>_<device>_<data>.csv)')
     args = parser.parse_args()
 
     devices = ['GPU', 'CPU'] if args.device == 'BOTH' else [args.device]
@@ -111,10 +146,13 @@ def main():
     for d in devices:
         results[d] = run_bench(args.workflow, args.n, d)
 
-    print_table(results, args.n)
+    print_table(results, args.n, args.workflow, args.device)
 
-    if args.csv:
-        save_csv(results, args.n, args.csv)
+    wksp_name = os.path.splitext(os.path.basename(args.workflow))[0]
+    date_str  = datetime.now().strftime("%Y%m%d_%H%M%S")
+    csv_path  = args.csv or os.path.join("out", f"{wksp_name}_{args.device}_{date_str}.csv")
+    os.makedirs(os.path.dirname(csv_path), exist_ok=True)
+    save_csv(results, args.n, csv_path)
 
 
 if __name__ == '__main__':

--- a/execBench.py
+++ b/execBench.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+execBench.py — benchmark de funções VGL via execWorkflowGen.py
+
+Uso:
+  python3 execBench.py <workflow.wksp> [--n N] [--device GPU|CPU|BOTH] [--csv out.csv]
+
+Exemplos:
+  python3 execBench.py data/workflows/fundus/fundus.wksp --n 100 --device GPU
+  python3 execBench.py data/workflows/fundus/fundus.wksp --n 100 --device BOTH --csv bench.csv
+"""
+import argparse
+import subprocess
+import sys
+import re
+import csv
+import os
+
+
+def run_bench(workflow, n, device):
+    """Executa execWorkflowGen.py e retorna dict {func: ms}."""
+    print(f"  Rodando {n} iterações [{device}]...", flush=True)
+    result = subprocess.run(
+        [sys.executable, "execWorkflowGen.py", workflow, str(n), device],
+        capture_output=True, text=True,
+        env=os.environ.copy(),
+    )
+    timings = {}
+    for line in result.stdout.splitlines():
+        m = re.match(r'\[BENCH\]\s+(.+?):\s+([\d.]+)\s+ms', line)
+        if m:
+            func, ms = m.group(1), float(m.group(2))
+            if func != 'TOTAL':
+                timings[func] = ms
+    if not timings:
+        print(f"  Aviso: nenhuma linha [BENCH] capturada. Stderr:", file=sys.stderr)
+        for line in result.stderr.splitlines()[-5:]:
+            print(f"    {line}", file=sys.stderr)
+    return timings
+
+
+def print_table(results, n):
+    devices = list(results.keys())
+    all_funcs = list(dict.fromkeys(f for d in devices for f in results[d]))
+    n_ops = len(all_funcs)
+
+    col_w = 16
+    width = 38 + col_w * len(devices)
+    col_header = "".join(f"{f'{d} (ms)':>{col_w}}" for d in devices)
+    header = f"{'Operação':<38}" + col_header
+
+    print(f"\nBenchmark — {n} iterações × {n_ops} operações")
+    print("─" * width)
+    print(header)
+    print("─" * width)
+
+    totals = {d: 0.0 for d in devices}
+    for func in all_funcs:
+        row = f"{func:<38}"
+        for d in devices:
+            val = results[d].get(func, 0.0)
+            totals[d] += val
+            row += f"{val:>{col_w}.3f}"
+        print(row)
+
+    print("─" * width)
+    total_row = f"{'TOTAL':<38}"
+    for d in devices:
+        total_row += f"{totals[d]:>{col_w}.3f}"
+    print(total_row)
+    print("─" * width)
+
+
+def save_csv(results, n, path):
+    devices = list(results.keys())
+    all_funcs = list(dict.fromkeys(f for d in devices for f in results[d]))
+
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow(['Operação'] + [f'{d} (ms)' for d in devices])
+        totals = {d: 0.0 for d in devices}
+        for func in all_funcs:
+            row = [func]
+            for d in devices:
+                val = results[d].get(func, 0.0)
+                totals[d] += val
+                row.append(f'{val:.3f}')
+            writer.writerow(row)
+        writer.writerow(['TOTAL'] + [f'{totals[d]:.3f}' for d in devices])
+
+    print(f"\nSalvo em: {path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Benchmark de funções VGL',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('workflow', help='Arquivo .wksp')
+    parser.add_argument('--n', type=int, default=100,
+                        help='Número de iterações por função (padrão: 100)')
+    parser.add_argument('--device', default='GPU', choices=['GPU', 'CPU', 'BOTH'],
+                        help='Device a usar (padrão: GPU)')
+    parser.add_argument('--csv', metavar='FILE',
+                        help='Salvar resultado em CSV')
+    args = parser.parse_args()
+
+    devices = ['GPU', 'CPU'] if args.device == 'BOTH' else [args.device]
+    results = {}
+    for d in devices:
+        results[d] = run_bench(args.workflow, args.n, d)
+
+    print_table(results, args.n)
+
+    if args.csv:
+        save_csv(results, args.n, args.csv)
+
+
+if __name__ == '__main__':
+    main()

--- a/execWorkflowGen.py
+++ b/execWorkflowGen.py
@@ -36,12 +36,13 @@ def tratnum(num):
     return listnumpy
 
 
-nSteps = 1
+nSteps = int(sys.argv[2]) if len(sys.argv) > 2 else 1
 msg = ""
-CPU = cl.device_type.CPU 
+CPU = cl.device_type.CPU
 GPU = cl.device_type.GPU
 total = 0.0
-vl.vglClInit(GPU)
+_device = CPU if len(sys.argv) > 3 and sys.argv[3].upper() == 'CPU' else GPU
+vl.vglClInit(_device)
 
 
 workspace = Workspace()
@@ -2387,6 +2388,14 @@ def execute_workspace(workspace):
 
 
           GlyphExecutedUpdate(vGlyph.glyph_id, vglCvThreshold_dst, workspace)
+
+    import re as _re
+    for _line in msg.splitlines():
+        _m = _re.match(r'Tempo médio de \d+ execuções do método (.+): ([\d.]+) ms', _line)
+        if _m:
+            print(f"[BENCH] {_m.group(1)}: {_m.group(2)} ms")
+    if total > 0:
+        print(f"[BENCH] TOTAL: {round(total, 3)} ms")
 
 
 def _find_batch_glyph(ws):

--- a/interpretador.pl
+++ b/interpretador.pl
@@ -1522,12 +1522,13 @@ def tratnum(num):
     return listnumpy
 
 
-nSteps = 1
+nSteps = int(sys.argv[2]) if len(sys.argv) > 2 else 1
 msg = ""
-CPU = cl.device_type.CPU 
+CPU = cl.device_type.CPU
 GPU = cl.device_type.GPU
 total = 0.0
-vl.vglClInit(GPU)
+_device = CPU if len(sys.argv) > 3 and sys.argv[3].upper() == 'CPU' else GPU
+vl.vglClInit(_device)
 
 
 workspace = Workspace()
@@ -1880,6 +1881,14 @@ def execute_workspace(workspace):
                 cv2.imwrite(vpath, img_bgr)
                 print(f"Image saved to {vpath}")
                 GlyphExecutedUpdate(vGlyph.glyph_id, None, workspace)
+
+    import re as _re
+    for _line in msg.splitlines():
+        _m = _re.match(r'Tempo médio de \d+ execuções do método (.+): ([\d.]+) ms', _line)
+        if _m:
+            print(f"[BENCH] {_m.group(1)}: {_m.group(2)} ms")
+    if total > 0:
+        print(f"[BENCH] TOTAL: {round(total, 3)} ms")
 
 END_TEMPLATE
 


### PR DESCRIPTION
## Summary

- Novo `execBench.py` — orquestra `execWorkflowGen.py` como subprocess, parseia saída `[BENCH]` e formata tabela de tempos médios por função
- `execWorkflowGen.py` e `interpretador.pl` atualizados: `nSteps` e device lidos de `argv[2]`/`argv[3]` em vez de hardcoded
- `msg`/`total` agora impressos ao final de `execute_workspace` com prefixo `[BENCH]`
- CSV gerado automaticamente em `out/<workflow>_<device>_<data>.csv`
- Saída inclui: workflow, imagem + dimensões, device, data/hora

## Uso

```bash
python3 execBench.py data/workflows/fundus/fundus.wksp --n 100
python3 execBench.py data/workflows/fundus/fundus.wksp --n 1000 --device GPU --csv meu_bench.csv
```

## Test plan

- [x] GPU — 10 iterações, fundus.wksp — tabela impressa corretamente
- [x] CSV gerado automaticamente com nome padronizado
- [x] Dimensões da imagem lidas do .wksp sem dependência de execWorkflowGen.py